### PR TITLE
Fix config command for encryption fallback setting

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -31,7 +31,7 @@ def fab_authenticate_spn(
             "Environment variables FABRIC_CLIENT_ID, FABRIC_CLIENT_SECRET and FABRIC_TENANT_ID must be set"
         )
 
-    run_fab_command("config set fab_encryption_fallback_enabled true")
+    run_fab_command("config set encryption_fallback_enabled true")
 
     run_fab_command(
         f"auth login -u {client_id} -p {client_secret} --tenant {tenant_id}",


### PR DESCRIPTION
Corrected config setting - from fab_encryption_fallback_enabled to encryption_fallback_enabled